### PR TITLE
refactor: ファイル出力処理を独立したモジュールに移動

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ venv.bak/
 .idea/
 *.swp
 *.swo
+
+# Output
+output/*
+!output/.gitkeep

--- a/src/api/accounts.py
+++ b/src/api/accounts.py
@@ -11,19 +11,19 @@ class AccountsAPI:
     def __init__(self, token):
         load_dotenv()
         self._base_url = os.getenv('ANYPOINT_BASE_URL')
-        self._session = requests.Session()
-        self._session.headers.update({
+        self._organization_id = os.getenv('ANYPOINT_ORGANIZATION_ID')
+        self.__session = requests.Session()
+        self.__session.headers.update({
             'Authorization': f'Bearer {token}'
         })
-        self.__organization_id = os.getenv('ANYPOINT_ORGANIZATION_ID')
 
     def get_organization_environments(self):
         """組織内の環境の取得"""
-        url = f"{self._base_url}/accounts/api/organizations/{self.__organization_id}/environments"
+        url = f"{self._base_url}/accounts/api/organizations/{self._organization_id}/environments"
         payload = {
           'extended': False,
           'resolveTheme': False
         }
-        response = self._session.get(url, data=payload)
+        response = self.__session.get(url, data=payload)
         response.raise_for_status()
         return response.json()

--- a/src/api/api_manager.py
+++ b/src/api/api_manager.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""API MAnager API"""
+
+import os
+import requests
+from dotenv import load_dotenv
+
+class APIManagerClient:
+    """API Manager APIクライアント"""
+    def __init__(self, token, environments):
+        load_dotenv()
+        self._base_url = os.getenv('ANYPOINT_BASE_URL')
+        self.__session = requests.Session()
+        self.__session.headers.update({
+            'Authorization': f'Bearer {token}'
+        })
+        self._environments = environments
+
+    def get_applications(self):
+        """アプリケーションの取得"""
+        # environmentsを全件ループしてアプリケーションを取得
+        applications = []
+        for env in self._environments:
+          url = f"{self._base_url}/apimanager/api/v1/organizations/{env['org_id']}/environments/{env['env_id']}/apis"
+          params = {
+            'sort': 'name'
+          }
+          response = self.__session.get(url, params=params)
+          response.raise_for_status()
+
+          data = {
+            'name': env['name'],
+            'org_id': env['org_id'],
+            'env_id': env['env_id'],
+            'apis': response.json()
+          }
+          applications.append(data)
+        return applications

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
 """Anypoint Platform API Client"""
 
-import json
-import os
 from auth.client import AuthClient
 from api.accounts import AccountsAPI
 from api.api_manager import APIManagerClient
 from utils.config import Config
 from utils.exceptions import ConfigurationError
-from datetime import datetime
+from utils.file_output import FileOutput
 
 def main():
     """メイン処理"""
@@ -49,16 +47,8 @@ def main():
         applications = api_manager_client.get_applications()
         print("アプリケーションの取得に成功しました：")
 
-        # 出力先の準備
-        now = datetime.now()
-        timestamp_str = now.strftime("%Y%m%d_%H%M%S")
-        folder_path = os.path.join("output", timestamp_str)
-        os.makedirs(folder_path, exist_ok=True)
-
-        # 出力先へ出力
-        file_path = f'{folder_path}/applications.json'
-        with open(file_path, 'w', encoding='utf-8') as f:
-            json.dump(applications, f, indent=2, ensure_ascii=False)
+        # アプリケーション情報をファイルに出力
+        file_path = FileOutput.output_json(applications, 'applications.json')
         print(f"アプリケーションの出力に成功しました：{file_path}")
 
     except Exception as e:

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Anypoint Platform API Client"""
 
+import json
+import os
 from auth.client import AuthClient
 from api.accounts import AccountsAPI
+from api.api_manager import APIManagerClient
 from utils.config import Config
 from utils.exceptions import ConfigurationError
+from datetime import datetime
 
 def main():
     """メイン処理"""
@@ -32,10 +36,33 @@ def main():
         environments = []
         print("組織情報の取得に成功しました：")
         for env in organization['data']:
-            environments.append({"name": env['name'], "id": env['id']})
+            environments.append({"name": env['name'], "env_id": env['id'], "org_id": env['organizationId']})
 
     except Exception as e:
         print(f"組織情報の取得時にエラーが発生しました: {e}")
+
+    try:
+        # API Managerクライアントの初期化
+        api_manager_client = APIManagerClient(token, environments)
+
+        # アプリケーションの取得
+        applications = api_manager_client.get_applications()
+        print("アプリケーションの取得に成功しました：")
+
+        # 出力先の準備
+        now = datetime.now()
+        timestamp_str = now.strftime("%Y%m%d_%H%M%S")
+        folder_path = os.path.join("output", timestamp_str)
+        os.makedirs(folder_path, exist_ok=True)
+
+        # 出力先へ出力
+        file_path = f'{folder_path}/applications.json'
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(applications, f, indent=2, ensure_ascii=False)
+        print(f"アプリケーションの出力に成功しました：{file_path}")
+
+    except Exception as e:
+        print(f"アプリケーションの取得時にエラーが発生しました: {e}")
 
 if __name__ == "__main__":
     main()

--- a/src/utils/file_output.py
+++ b/src/utils/file_output.py
@@ -1,0 +1,33 @@
+"""ファイル出力を制御するモジュール"""
+
+import json
+import os
+from datetime import datetime
+
+
+class FileOutput:
+    """ファイル出力を制御するクラス"""
+
+    @staticmethod
+    def output_json(data: dict, filename: str) -> str:
+        """JSONデータをファイルに出力する
+
+        Args:
+            data (dict): 出力するデータ
+            filename (str): 出力ファイル名
+
+        Returns:
+            str: 出力したファイルのパス
+        """
+        # 出力先の準備
+        now = datetime.now()
+        timestamp_str = now.strftime("%Y%m%d_%H%M%S")
+        folder_path = os.path.join("output", timestamp_str)
+        os.makedirs(folder_path, exist_ok=True)
+
+        # 出力先へ出力
+        file_path = f'{folder_path}/{filename}'
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+
+        return file_path


### PR DESCRIPTION
## 変更内容

- ファイル出力処理を`utils/file_output.py`に移動
- `FileOutput`クラスを作成し、JSON出力処理をカプセル化
- `main.py`からファイル出力に関する直接的な処理を削除

## 変更理由

- 単一責任の原則に従い、ファイル出力処理を独立したモジュールに分離
- コードの再利用性を向上
- `main.py`の責務を明確化