### PR TITLE
refactor: アプリケーションのコンパクト化処理をapi_manager.pyに移動

### DIFF
--- a/src/api/api_manager.py
+++ b/src/api/api_manager.py
@@ -36,3 +36,32 @@ class APIManagerClient:
           }
           applications.append(data)
         return applications
+
+    def compact_applications(self, applications):
+        """アプリケーション情報を解析用にコンパクト化"""
+        compact_applications = []
+
+        # applications配列をループ
+        for app in applications:
+            compact_app = {
+                "env_name": app["env_name"],
+                "org_id": app["org_id"],
+                "env_id": app["env_id"],
+                "apis": []
+            }
+
+            # apis.assets内のapisを格納
+            if app["apis"]["assets"]:
+                compact_app["apis"] = []
+                for asset in app["apis"]["assets"]:
+                    for api in asset["apis"]:
+                        compact_app["apis"].append({
+                            "id": api["id"],
+                            "exchangeAssetName": asset["exchangeAssetName"],
+                            "instanceLabel": api["instanceLabel"],
+                            "status": api["status"]
+                        })
+
+            compact_applications.append(compact_app)
+
+        return compact_applications

--- a/src/main.py
+++ b/src/main.py
@@ -67,30 +67,7 @@ def main():
 
     try:
         # 環境別アプリケーション情報を解析用にコンパクト化
-        compact_applications = []
-
-        # applications配列をループ
-        for app in applications:
-            compact_app = {
-                "env_name": app["env_name"],
-                "org_id": app["org_id"],
-                "env_id": app["env_id"],
-                "apis": []
-            }
-
-            # apis.assets内のapisを格納
-            if app["apis"]["assets"]:
-                compact_app["apis"] = []
-                for asset in app["apis"]["assets"]:
-                    for api in asset["apis"]:
-                        compact_app["apis"].append({
-                            "id": api["id"],
-                            "exchangeAssetName": asset["exchangeAssetName"],
-                            "instanceLabel": api["instanceLabel"],
-                            "status": api["status"]
-                        })
-
-            compact_applications.append(compact_app)
+        compact_applications = api_manager_client.compact_applications(applications)
 
         # コンパクト化されたアプリケーション情報の出力
         if file_output and output_config.get_output_setting("applications_compact"):


### PR DESCRIPTION
## 変更内容
アプリケーションのコンパクト化処理を`main.py`から`api_manager.py`に移動しました。これにより、データ処理の責任が適切に分離され、コードの保守性が向上しました。

### 主な変更点
1. `api_manager.py`に`compact_applications`メソッドを追加
   - アプリケーション情報をコンパクト化する処理を移動
   - 引数として`applications`を受け取り、コンパクト化されたデータを返す

2. `main.py`の修正
   - コンパクト化処理を削除
   - `api_manager_client.compact_applications(applications)`を呼び出すように変更

## 動作確認
- アプリケーション情報の取得が正常に動作することを確認
- コンパクト化処理が正常に動作することを確認
- 出力ファイルが正しく生成されることを確認