### PR TITLE
ティア情報の取得と出力機能を追加

### DIFF
--- a/src/utils/output_config.py
+++ b/src/utils/output_config.py
@@ -59,6 +59,7 @@ class OutputConfig:
             "policies": "policies.json",
             "contracts": "contracts.json",
             "alerts": "alerts.json",
+            "tiers": "tiers.json",
             "api_manager": "api_manager.json"
         }
         return self._config.get(env_key, default_filenames.get(key, f"{key}.json"))


### PR DESCRIPTION
## 変更内容

- API Managerのティア情報を取得する機能を追加
- ティア情報を個別のJSONファイルとして出力する機能を追加
- API Manager情報の統合出力にティア情報を含めるように変更

## 影響範囲

- `src/services/api_manager_service.py`
  - ティア情報の非同期取得処理を追加
  - ティア情報の出力処理を追加
  - API Manager情報の統合にティア情報を追加

- `src/utils/output_config.py`
  - ティア情報の出力設定を追加（デフォルトファイル名：`tiers.json`）