### PR TITLE
fix: CloudHub APIのパラメータを修正

### DIFF
--- a/src/api/cloudhub.py
+++ b/src/api/cloudhub.py
@@ -1,0 +1,42 @@
+import os
+from dotenv import load_dotenv
+import requests
+import aiohttp
+
+
+class CloudHubClient:
+    """CloudHub APIクライアント"""
+    def __init__(self, token, environments):
+        load_dotenv()
+        self._base_url = os.getenv('ANYPOINT_BASE_URL')
+        self.__session = requests.Session()
+        self.__session.headers.update({
+            'Authorization': f'Bearer {token}'
+        })
+        self._environments = environments
+
+    def get_applications(self):
+        """アプリケーションの取得"""
+        results = []
+        for env in self._environments:
+            url = f"{self._base_url}/cloudhub/api/v2/applications"
+            unique_headers = {
+                'X-ANYPNT-ENV-ID': env['env_id']
+            }
+            headers = self.__session.headers.copy()
+            headers.update(unique_headers)
+            response = self.__session.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+
+            for app in data:
+                results.append(app)
+
+        return results
+
+    async def get_status_async(self, session, app_id):
+        """アプリケーションステータスの非同期取得"""
+        url = f"{self._base_url}/cloudhub/api/v2/applications/{app_id}/status"
+        async with session.get(url, headers=self.__session.headers) as response:
+            response.raise_for_status()
+            return await response.json()

--- a/src/services/cloudhub_service.py
+++ b/src/services/cloudhub_service.py
@@ -1,0 +1,49 @@
+import asyncio
+import aiohttp
+from api.cloudhub import CloudHubClient
+from utils.file_output import FileOutput
+from utils.output_config import OutputConfig
+
+
+class CloudHubService:
+    """CloudHub Service"""
+
+    def __init__(self, cloudhub_client: CloudHubClient, file_output: FileOutput, output_config: OutputConfig):
+        """初期化"""
+        self._cloudhub_client = cloudhub_client
+        self._file_output = file_output
+        self._output_config = output_config
+
+    async def get_cloudhub_info(self):
+        """CloudHub情報の取得"""
+        try:
+            # アプリケーションの取得
+            applications = self._cloudhub_client.get_applications()
+            if len(applications) > 0 and self._output_config.output_applications:
+                self._file_output.output_json(applications, "applications")
+
+            # アプリケーションステータスの取得
+            statuses = []
+            async with aiohttp.ClientSession() as session:
+                tasks = []
+                for app in applications:
+                    tasks.append(self._cloudhub_client.get_status_async(session, app["domain"]))
+
+                if len(tasks) > 0:
+                    status_results = await asyncio.gather(*tasks, return_exceptions=True)
+                    for i, status_result in enumerate(status_results):
+                        if isinstance(status_result, Exception):
+                            print(f"Error getting status: {str(status_result)}")
+                            continue
+
+                        statuses.append({
+                            "domain": applications[i]["domain"],
+                            **status_result
+                        })
+
+                    if len(statuses) > 0 and self._output_config.output_status:
+                        self._file_output.output_json(statuses, "application_status")
+
+        except Exception as e:
+            print(f"Error in get_cloudhub_info: {str(e)}")
+            raise


### PR DESCRIPTION
## 概要
CloudHub APIの仕様に合わせてパラメータを修正しました。

## 修正内容
- CloudHubClientから不要なorg_id, env_idを削除
- CloudHubServiceのステータス取得処理を修正
- アプリケーションIDをdomainに変更

## 影響範囲
- CloudHubClientのAPI呼び出し
- CloudHubServiceのステータス取得処理