### PR TITLE
API ManagerとCloudHubの情報取得処理を非同期化

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -56,21 +56,20 @@ async def main():
         })
 
     try:
-        # API Manager情報の取得
+        # API ManagerとCloudHubのクライアントを初期化
         api_manager_client = APIManagerClient(access_token, formatted_environments)
         api_manager_service = APIManagerService(api_manager_client, file_output, output_config)
-        await api_manager_service.get_api_manager_info()
-    except Exception as e:
-        print(f"API Manager情報の取得時にエラーが発生しました: {e}")
-        return
-
-    try:
-        # CloudHub情報の取得
+        
         cloudhub_client = CloudHubClient(access_token, formatted_environments)
         cloudhub_service = CloudHubService(cloudhub_client, file_output, output_config)
-        await cloudhub_service.get_cloudhub_info()
+        
+        # 両方の情報を非同期で取得
+        await asyncio.gather(
+            api_manager_service.get_api_manager_info(),
+            cloudhub_service.get_cloudhub_info()
+        )
     except Exception as e:
-        print(f"CloudHub情報の取得時にエラーが発生しました: {e}")
+        print(f"情報取得時にエラーが発生しました: {e}")
         return
 
     print("処理を完了しました。")

--- a/src/main.py
+++ b/src/main.py
@@ -59,10 +59,10 @@ async def main():
         # API ManagerとCloudHubのクライアントを初期化
         api_manager_client = APIManagerClient(access_token, formatted_environments)
         api_manager_service = APIManagerService(api_manager_client, file_output, output_config)
-        
+
         cloudhub_client = CloudHubClient(access_token, formatted_environments)
         cloudhub_service = CloudHubService(cloudhub_client, file_output, output_config)
-        
+
         # 両方の情報を非同期で取得
         await asyncio.gather(
             api_manager_service.get_api_manager_info(),
@@ -72,7 +72,7 @@ async def main():
         print(f"情報取得時にエラーが発生しました: {e}")
         return
 
-    print("処理を完了しました。")
+    print("処理を完了しました：")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/services/api_manager_service.py
+++ b/src/services/api_manager_service.py
@@ -22,9 +22,9 @@ class APIManagerService:
             # アプリケーションの取得
             applications = await self._api_manager_client.get_applications()
             compact_applications = self._api_manager_client.compact_applications(applications)
-            print("アプリケーションの取得に成功しました：")
+            print("get_api_manager_infoに成功しました：")
         except Exception as e:
-            print(f"アプリケーションの取得時にエラーが発生しました: {e}")
+            print(f"get_api_manager_info時にエラーが発生しました: {e}")
             return None
 
         try:
@@ -59,7 +59,7 @@ class APIManagerService:
 
                 # 結果を整理
                 if not compact_applications:
-                    print("アプリケーション情報が見つかりません")
+                    print("get_api_manager_info:アプリケーション情報が見つかりません")
                     return None
 
                 # API情報を含む環境をカウント
@@ -69,11 +69,11 @@ class APIManagerService:
                         api_count += len(env["apis"])
 
                 if api_count == 0:
-                    print("処理対象のAPIが見つかりません")
+                    print("get_api_manager_info:処理対象のAPIが見つかりません")
                     return None
 
                 if len(results) != 4 * api_count:
-                    print(f"予期しない結果数です: {len(results)} (expected: {4 * api_count})")
+                    print(f"get_api_manager_info:予期しない結果数です: {len(results)} (expected: {4 * api_count})")
                     return None
 
                 result_index = 0
@@ -151,14 +151,14 @@ class APIManagerService:
                 if self._file_output and self._output_config.get_output_setting("api_manager"):
                     filename = self._output_config.get_output_filename("api_manager")
                     file_path = self._file_output.output_json(compact_applications, filename)
-                    print(f"API Manager情報の出力に成功しました：{file_path}")
+                    print(f"get_api_manager_info:API Manager情報の出力に成功しました：{file_path}")
 
                 return compact_applications
 
             except Exception as e:
-                print(f"API Manager情報の統合時にエラーが発生しました: {e}")
+                print(f"get_api_manager_info:API Manager情報の統合時にエラーが発生しました: {e}")
                 return None
 
         except Exception as e:
-            print(f"ポリシー情報、Contracts情報、アラート情報の取得時にエラーが発生しました: {e}")
+            print(f"get_api_manager_info:補足情報の取得時にエラーが発生しました: {e}")
             return None

--- a/src/services/cloudhub_service.py
+++ b/src/services/cloudhub_service.py
@@ -19,14 +19,14 @@ class CloudHubService:
         try:
             # アプリケーションの取得
             applications = await self._cloudhub_client.get_applications()
-            print("アプリケーションの取得に成功しました：")
+            print("get_cloudhub_infoに成功しました：")
 
         except Exception as e:
-            print(f"アプリケーションの取得時にエラーが発生しました: {e}")
+            print(f"get_cloudhub_info時にエラーが発生しました: {e}")
             raise
 
         # CloudHub情報の出力
         if self._file_output and self._output_config.get_output_setting("cloudhub"):
             filename = self._output_config.get_output_filename("cloudhub")
             file_path = self._file_output.output_json(applications, filename)
-            print(f"CloudHub情報の出力に成功しました：{file_path}")
+            print(f"get_cloudhub_info:CloudHub情報の出力に成功しました：{file_path}")


### PR DESCRIPTION
## 変更内容

1. `asyncio.gather()`を使用して、API ManagerとCloudHubの情報取得を並行実行するように変更
2. 両方のクライアントの初期化を1つのtryブロックにまとめ、エラーハンドリングを統合
3. 各サービスの処理コメントを明確化し、出力メッセージを統一

## 期待される効果

- 両方の情報取得処理が並行して実行されるため、全体の実行時間が短縮
- エラーハンドリングがシンプルになり、コードの可読性が向上
- 将来的に新しい非同期処理を追加する場合も、`asyncio.gather()`に追加するだけで対応可能

## 動作確認済み
- ローカル環境での動作確認完了
- 正常系、エラー系ともに期待通りの動作を確認