### PR TITLE
Mask proxy credentials in error logs

### DIFF
--- a/src/api_manager_export.py
+++ b/src/api_manager_export.py
@@ -4,6 +4,7 @@
 import asyncio
 
 from src.export_common import export_runtime, write_export_output
+from src.utils.error_sanitizer import sanitize_error_message
 
 
 async def export_api_manager_info(
@@ -31,7 +32,10 @@ async def export_api_manager_info(
                 output_config,
             )
     except Exception as exc:
-        print(f"Failed to export API Manager information: {exc}")
+        print(
+            "Failed to export API Manager information: "
+            f"{sanitize_error_message(exc)}"
+        )
         raise
 
 

--- a/src/cloudhub_export.py
+++ b/src/cloudhub_export.py
@@ -4,6 +4,7 @@
 import asyncio
 
 from src.export_common import export_runtime, write_export_output
+from src.utils.error_sanitizer import sanitize_error_message
 
 
 async def export_cloudhub_info(
@@ -51,7 +52,10 @@ async def _export_cloudhub_info(
         print("Runtime Manager information exported successfully.")
         return formatted_applications
     except Exception as exc:
-        print(f"Failed to export Runtime Manager information: {exc}")
+        print(
+            "Failed to export Runtime Manager information: "
+            f"{sanitize_error_message(exc)}"
+        )
         raise
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from src.api_manager_export import export_api_manager_info
 from src.auth.client import AuthClient
 from src.cloudhub_export import export_cloudhub_info
 from src.utils.config import Config
+from src.utils.error_sanitizer import sanitize_error_message
 from src.utils.file_output import FileOutput
 from src.utils.http_client import AsyncHTTPClient
 from src.utils.output_config import OutputConfig
@@ -30,7 +31,7 @@ async def main():
             access_token = await auth_client.get_access_token()
             print("Access token retrieved successfully.")
         except Exception as exc:
-            print(f"Failed to retrieve access token: {exc}")
+            print(f"Failed to retrieve access token: {sanitize_error_message(exc)}")
             return 1
 
         try:
@@ -38,7 +39,10 @@ async def main():
             environments = await accounts_api.get_organization_environments()
             print("Organization environments retrieved successfully.")
         except Exception as exc:
-            print(f"Failed to retrieve organization environments: {exc}")
+            print(
+                "Failed to retrieve organization environments: "
+                f"{sanitize_error_message(exc)}"
+            )
             return 1
 
         formatted_environments = [
@@ -70,7 +74,7 @@ async def main():
                 ),
             )
         except Exception as exc:
-            print(f"Failed to export information: {exc}")
+            print(f"Failed to export information: {sanitize_error_message(exc)}")
             return 1
 
     print("Completed.")

--- a/src/utils/error_sanitizer.py
+++ b/src/utils/error_sanitizer.py
@@ -1,0 +1,26 @@
+"""Helpers for removing secrets from error messages before logging."""
+
+import re
+from urllib.parse import urlsplit, urlunsplit
+
+
+_URL_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*://[^\s'\"<>]+")
+
+
+def sanitize_error_message(error):
+    """Mask credentials embedded in URL-like text within an error message."""
+    return _URL_PATTERN.sub(_sanitize_url_match, str(error))
+
+
+def _sanitize_url_match(match):
+    return sanitize_url(match.group(0))
+
+
+def sanitize_url(url):
+    """Return a copy of the URL with any userinfo replaced."""
+    parts = urlsplit(url)
+    if not parts.netloc or "@" not in parts.netloc:
+        return url
+
+    host = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit(parts._replace(netloc=f"***@{host}"))

--- a/tests/test_api_manager_export.py
+++ b/tests/test_api_manager_export.py
@@ -276,3 +276,31 @@ async def test_export_api_manager_info_does_not_create_owned_client_when_injecte
     assert result == [
         {"env_name": "Sandbox", "org_id": "org-1", "env_id": "env-1", "apis": []}
     ]
+
+
+@pytest.mark.asyncio
+async def test_export_api_manager_info_masks_proxy_credentials_in_error_output(
+    monkeypatch, capsys
+):
+    """It redacts proxy userinfo before logging export failures."""
+    monkeypatch.setenv("ANYPOINT_BASE_URL", "https://example.com")
+    file_output, output_config = build_output_mocks(filename="api_manager.json")
+
+    with pytest.raises(RuntimeError):
+        await export_api_manager_info(
+            "token",
+            [{"name": "Sandbox", "org_id": "org-1", "env_id": "env-1"}],
+            file_output,
+            output_config,
+            http_client=FakeHTTPClient(
+                lambda url, **kwargs: RuntimeError(
+                    "proxy http://user:pass@proxy.local:8080 refused "
+                    "https://example.com/apimanager/api/v1/organizations/org-1"
+                )
+            ),
+        )
+
+    captured = capsys.readouterr()
+    assert "http://***@proxy.local:8080" in captured.out
+    assert "https://example.com/apimanager/api/v1/organizations/org-1" in captured.out
+    assert "user:pass" not in captured.out

--- a/tests/test_cloudhub_export.py
+++ b/tests/test_cloudhub_export.py
@@ -113,3 +113,31 @@ async def test_export_cloudhub_info_does_not_create_owned_client_when_injected(
     )
 
     assert result[0]["apis"] == [{"id": "app-1", "status": "STARTED"}]
+
+
+@pytest.mark.asyncio
+async def test_export_cloudhub_info_masks_proxy_credentials_in_error_output(
+    monkeypatch, capsys
+):
+    """It redacts proxy userinfo before logging export failures."""
+    monkeypatch.setenv("ANYPOINT_BASE_URL", "https://example.com")
+    file_output, output_config = build_output_mocks(filename="cloudhub.json")
+
+    with pytest.raises(RuntimeError):
+        await export_cloudhub_info(
+            "token",
+            [{"name": "Sandbox", "org_id": "org-1", "env_id": "env-1"}],
+            file_output,
+            output_config,
+            http_client=FakeHTTPClient(
+                lambda url, **kwargs: RuntimeError(
+                    "proxy http://user:pass@proxy.local:8080 refused "
+                    "https://example.com/cloudhub/api/v2/applications"
+                )
+            ),
+        )
+
+    captured = capsys.readouterr()
+    assert "http://***@proxy.local:8080" in captured.out
+    assert "https://example.com/cloudhub/api/v2/applications" in captured.out
+    assert "user:pass" not in captured.out

--- a/tests/test_error_sanitizer.py
+++ b/tests/test_error_sanitizer.py
@@ -1,0 +1,25 @@
+"""Tests for secret-safe error logging helpers."""
+
+from src.utils.error_sanitizer import sanitize_error_message
+
+
+def test_sanitize_error_message_masks_url_userinfo():
+    """It redacts credentials while keeping the host visible."""
+    message = (
+        "proxy http://user:pass@proxy.local:8080 refused "
+        "https://anypoint.mulesoft.com/accounts"
+    )
+
+    sanitized = sanitize_error_message(message)
+
+    assert sanitized == (
+        "proxy http://***@proxy.local:8080 refused "
+        "https://anypoint.mulesoft.com/accounts"
+    )
+
+
+def test_sanitize_error_message_leaves_urls_without_userinfo_unchanged():
+    """It preserves unrelated URLs so failures stay understandable."""
+    message = "request failed for https://anypoint.mulesoft.com/accounts"
+
+    assert sanitize_error_message(message) == message

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -109,3 +109,33 @@ async def test_main_returns_one_when_export_fails(monkeypatch):
     monkeypatch.setattr(main_module, "export_cloudhub_info", export_cloudhub_info)
 
     assert await main_module.main() == 1
+
+
+@pytest.mark.asyncio
+async def test_main_masks_proxy_credentials_in_error_output(monkeypatch, capsys):
+    """It redacts proxy userinfo before printing failures."""
+    monkeypatch.setattr(main_module, "Config", DummyConfig)
+    monkeypatch.setattr(main_module, "OutputConfig", DummyOutputConfig)
+    monkeypatch.setattr(main_module, "FileOutput", DummyFileOutput)
+    monkeypatch.setattr(main_module, "AsyncHTTPClient", DummyHTTPClientContext)
+    monkeypatch.setattr(main_module, "AuthClient", DummyAuthClient)
+    monkeypatch.setattr(main_module, "AccountsAPI", DummyAccountsAPI)
+
+    async def export_api_manager_info(*args, **kwargs):
+        raise RuntimeError(
+            "proxy http://user:pass@proxy.local:8080 refused "
+            "https://anypoint.mulesoft.com/accounts"
+        )
+
+    async def export_cloudhub_info(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(main_module, "export_api_manager_info", export_api_manager_info)
+    monkeypatch.setattr(main_module, "export_cloudhub_info", export_cloudhub_info)
+
+    assert await main_module.main() == 1
+
+    captured = capsys.readouterr()
+    assert "http://***@proxy.local:8080" in captured.out
+    assert "https://anypoint.mulesoft.com/accounts" in captured.out
+    assert "user:pass" not in captured.out


### PR DESCRIPTION
## Summary\n- add a shared error sanitizer that redacts URL userinfo before logging\n- apply sanitized logging in the main flow and both export entrypoints\n- add regression tests covering sanitizer behavior and redacted output\n\n## Testing\n- .\\.venv\\Scripts\\python -m pytest tests/test_error_sanitizer.py tests/test_main.py tests/test_api_manager_export.py tests/test_cloudhub_export.py\n\nCloses #34